### PR TITLE
fix(102): Markdown fix for o1/o3 models

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -103,10 +103,13 @@ def openai_o1_o3_handler(payload):
     # For newer o1/o3 models, replace "system" with "developer".
     if payload["messages"][0]["role"] == "system":
         model_lower = payload["model"].lower()
-        if model_lower.startswith("o1-mini") or model_lower.startswith("o1-preview"):
-            payload["messages"][0]["role"] = "user"
-        else:
-            payload["messages"][0]["role"] = "developer"
+        role = "user" if model_lower.startswith("o1-mini") or model_lower.startswith("o1-preview") else "developer"
+        payload["messages"][0]["role"] = role
+    else:
+        role = payload["messages"][0]["role"]
+
+    # Fix: o1 and o3 do not format markdown by default, so it must be enabled.
+    payload["messages"].insert(0, {"role": role, "content": "Formatting re-enabled"})
 
     return payload
 


### PR DESCRIPTION
### Description

Prepended a markdown formatting message to allow openai o1/o3 models to emit markdown formatting. This solution was suggested in this help [thread](https://community.openai.com/t/o3-mini-does-not-format-text-in-api/1113222/6), and also referenced in [openai documentation](https://platform.openai.com/docs/guides/reasoning-best-practices#how-to-prompt-reasoning-models-effectively).


### Screenshots or Videos

Old behavior:
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/341899f3-6b03-482e-b4f4-388375ff2e0b" />

New behavior:
<img width="1004" alt="image" src="https://github.com/user-attachments/assets/34505360-dae0-45a3-9fb3-eca8d361ac6e" />

